### PR TITLE
Update publish_gpt_index_package.sh

### DIFF
--- a/scripts/publish_gpt_index_package.sh
+++ b/scripts/publish_gpt_index_package.sh
@@ -10,4 +10,4 @@ twine upload dist/*
 # twine upload -r testpypi dist/*
 
 # cleanup
-rm -rf build dist *.egg-info
+rm -rf build dist *.egg-info/


### PR DESCRIPTION
Adding a trailing / after *.egg-info specifies that you're explicitly targeting directories with the .egg-info extension for deletion, rather than files. This way, you'll avoid accidental deletion of files that might match the pattern.

