### PR TITLE
Corrected Float Extraction Logic in 'extract_float_given_response

### DIFF
--- a/experimental/classifier/utils.py
+++ b/experimental/classifier/utils.py
@@ -68,7 +68,7 @@ def extract_float_given_response(response: str, n: int = 1) -> Optional[float]:
         if new_numbers is None:
             return None
         else:
-            return float(numbers[0])
+            return float(new_numbers[0])
     else:
         return float(numbers[0])
 

--- a/scripts/publish_gpt_index_package.sh
+++ b/scripts/publish_gpt_index_package.sh
@@ -10,4 +10,4 @@ twine upload dist/*
 # twine upload -r testpypi dist/*
 
 # cleanup
-rm -rf build dist *.egg-info
+rm -rf build dist *.egg-info/


### PR DESCRIPTION
Chnages in experimental/classifier/utils.py

The code is attempting to convert the extracted number to a float. However, in the case where no floats are found initially (len(numbers) == 0), it attempts to convert the previously extracted new_numbers, but mistakenly uses float(numbers[0]) instead of float(new_numbers[0]). This might result in an error or incorrect behavior when trying to extract and convert integers to floats.